### PR TITLE
Use nca as a library

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -18,7 +18,7 @@ jobs:
           submodules: recursive
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v2.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -25,7 +25,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8
-          pip install -r requirements.txt
+          pip install network-config-analyzer
       - name: Lint with flake8
         run: flake8 src --count --max-complexity=10 --max-line-length=127 --statistics
       - name: Run all tests

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8
-          pip install network-config-analyzer
+          pip install -r requirements.txt
       - name: Lint with flake8
         run: flake8 src --count --max-complexity=10 --max-line-length=127 --statistics
       - name: Run all tests

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8
-          pip install --no-deps -r requirements.txt
+          pip install -r requirements.txt
       - name: Lint with flake8
         run: flake8 src --count --max-complexity=10 --max-line-length=127 --statistics
       - name: Run all tests

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8
-          pip install -r network-config-analyzer/requirements.txt
+          pip install -r requirements.txt
       - name: Lint with flake8
         run: flake8 src --count --max-complexity=10 --max-line-length=127 --statistics
       - name: Run all tests

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8
-          pip install -r requirements.txt
+          pip install --no-deps -r requirements.txt
       - name: Lint with flake8
         run: flake8 src --count --max-complexity=10 --max-line-length=127 --statistics
       - name: Run all tests

--- a/.github/workflows/test-push.yml
+++ b/.github/workflows/test-push.yml
@@ -39,4 +39,4 @@ jobs:
           GHE_TOKEN: ${{ github.token }}
         run: |
           cd tests
-          python run_all_tests.py --nca_path ${{ github.workspace }}/network-config-analyzer/network-config-analyzer
+          python run_all_tests.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/np-guard/nca:1.0
 
+COPY requirements.txt .
+RUN pip install --no-deps -r ./requirements.txt
+
 COPY src/ /baseline-rules-verifier/src/
 COPY baseline-rules/ /baseline-rules-verifier/baseline-rules/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-FROM ghcr.io/np-guard/nca:1.0
+FROM python:3.8-slim
 
+RUN python -m pip install -U pip wheel setuptools
 COPY requirements.txt .
-RUN pip install --no-deps -r ./requirements.txt
+RUN pip install -r ./requirements.txt
+
+RUN apt-get update && apt-get install curl -y
+
+RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" --output /usr/local/bin/kubectl
+RUN chmod +x /usr/local/bin/kubectl
+
+RUN curl -L https://github.com/projectcalico/calicoctl/releases/download/v3.3.1/calicoctl --output /usr/local/bin/calicoctl
+RUN chmod +x /usr/local/bin/calicoctl
 
 COPY src/ /baseline-rules-verifier/src/
 COPY baseline-rules/ /baseline-rules-verifier/baseline-rules/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ This application verifies the connectivity in a given Kubernetes cluster
 ### Requirements:
 
 * Python 3.8 or above
-* An installation of [NCA](https://github.com/IBM/network-config-analyzer)
 
 ### Run from a docker image
 ```commandline
@@ -39,4 +38,3 @@ python src/baseline_verify.py -b baseline-rules/examples/allow_access_to_google.
 * `--pr_url <url>` - add a PR comment with verification output, using the given API url
 * `--format <text_format>` - Use the given text_format to format output. Supported formats are "txt" and "md"
 * `--ghe_token <token>` - Use the given token to access GitHub repos
-* `--nca_path <nca_path>` - Specify the path to where [Network-Config-Analyzer](https://github.com/IBM/network-config-analyzer) is installed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML>=5.3.1
-network-config-analyzer>=1.3.1
+network-config-analyzer>=1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-PyGithub>=1.53
-ruamel.yaml>=0.16.12
 PyYAML>=5.3.1
-greenery>=3.3.2
 network-config-analyzer>=1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ ruamel.yaml>=0.16.12
 Flask>=2.0.0
 PyYAML>=5.3.1
 greenery>=3.3.2
+network-config-analyzer>=1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 PyGithub>=1.53
 ruamel.yaml>=0.16.12
-Flask>=2.0.0
 PyYAML>=5.3.1
 greenery>=3.3.2
 network-config-analyzer>=1.3.1

--- a/src/baseline_verify.py
+++ b/src/baseline_verify.py
@@ -129,8 +129,8 @@ class NetpolVerifier:
                 yaml.dump_all(policies_list, baseline_file)
 
             query = '--forbids' if rule.action == BaselineRuleAction.deny else '--permits'
-            fixed_args += [query, str(rule_filename.absolute())]
-            nca_run, details = self._run_network_config_analyzer(fixed_args, args.debug)
+            nca_run, details = self._run_network_config_analyzer(fixed_args + [query, str(rule_filename.absolute())],
+                                                                 args.debug)
             rule_results.append(RuleResults(rule.name, nca_run == 0, details))
             try:
                 os.remove(rule_filename)

--- a/src/baseline_verify.py
+++ b/src/baseline_verify.py
@@ -124,10 +124,7 @@ class NetpolVerifier:
             nca_run, details = self._run_network_config_analyzer(fixed_args + [query, str(rule_filename.absolute())],
                                                                  args.debug)
             rule_results.append(RuleResults(rule.name, nca_run == 0, details))
-            try:
-                os.remove(rule_filename)
-            except PermissionError:
-                print(f'{rule_filename} could not be deleted automatically', file=sys.stderr)
+            os.remove(rule_filename)
 
         output = '\n'.join(rule_result.to_str(args.format) for rule_result in rule_results)
         num_violated_rules = len([rule_result for rule_result in rule_results if not rule_result.satisfied])

--- a/src/baseline_verify.py
+++ b/src/baseline_verify.py
@@ -8,14 +8,17 @@ This module allows verifying a set of network policies against a set of baseline
 """
 
 import argparse
-import subprocess
 import os
 import sys
 import json
+from contextlib import contextmanager
 from dataclasses import dataclass
+from io import StringIO
 from pathlib import Path
 from urllib import request
 import yaml
+from nca import nca
+
 
 base_dir = Path(__file__).parent.resolve()
 common_services_dir = (base_dir / '../baseline-rules/src').resolve()
@@ -62,11 +65,48 @@ class NetpolVerifier:
     The main class for verifying a cluster connectivity against baseline rules.
     Converts baseline rules to k8s NetworkPolicy and runs NCA to verify cluster connectivity.
     """
-    def __init__(self, netpol_file, baseline_rules_file, repo, nca_path):
+    def __init__(self, netpol_file, baseline_rules_file, repo):
         self.netpol_file = netpol_file
         self.baseline_rules = BaselineRules(baseline_rules_file)
         self.repo = repo
-        self.nca_path = nca_path
+
+    @contextmanager
+    def _hide_stderr(self):
+        new_stderr = os.dup(2)
+        dev_null = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(dev_null, 2)
+        os.close(dev_null)
+        yield
+        os.dup2(new_stderr, 2)
+
+    def _run_network_config_analyzer(self, nca_args, debug_mode):
+        # redirecting nca's stdout to a buffer
+        old_stdout = sys.stdout
+        sys.stdout = new_stdout = StringIO()
+        # call nca's main function considering debug mode to print or hide the nca's stderr output
+        if debug_mode is not None:
+            nca_run = nca.nca_main(nca_args)
+        else:  # if debug mode is off , nca's stderr messages are hidden
+            with self._hide_stderr():
+                nca_run = nca.nca_main(nca_args)
+        # read nca's output values from the redirected stdout
+        nca_stdout = new_stdout.getvalue()
+        # stop redirecting stdout to the buffer
+        sys.stdout = old_stdout
+
+        if debug_mode is not None:
+            details = nca_stdout
+        elif nca_run != 0:
+            topology_output_words = ['cluster has', 'unique endpoints', 'namespaces']
+            nca_out = nca_stdout.split('\n')
+            # Remove nca's output about cluster topology info to set details output
+            if all(word in nca_out[1] for word in topology_output_words):
+                details = '\n\n'.join(nca_out[2:5])
+            else:
+                details = '\n\n'.join(nca_out[1:4])
+        else:
+            details = ''
+        return nca_run, details
 
     def verify(self, args):
         """
@@ -79,8 +119,7 @@ class NetpolVerifier:
             print('No rules to check')
             return 0
 
-        fixed_args = [sys.executable, Path(self.nca_path, 'nca.py'), '--base_np_list', self.netpol_file,
-                      '--pod_list', self.repo, '--ns_list', self.repo]
+        fixed_args = ['--base_np_list', self.netpol_file, '--pod_list', self.repo, '--ns_list', self.repo]
 
         rule_results = []
         for rule in self.baseline_rules:
@@ -90,21 +129,13 @@ class NetpolVerifier:
                 yaml.dump_all(policies_list, baseline_file)
 
             query = '--forbids' if rule.action == BaselineRuleAction.deny else '--permits'
-            nca_run = subprocess.run(fixed_args + [query, rule_filename], capture_output=True, text=True, check=False)
-            if args.debug is not None:
-                details = nca_run.stdout + '\n' + nca_run.stderr
-            elif nca_run.returncode != 0:
-                topology_output_words = ['cluster has', 'unique endpoints', 'namespaces']
-                nca_stdout = str(nca_run.stdout).split('\n')
-                # Remove nca's output about cluster topology info to set details output
-                if all(word in nca_stdout[1] for word in topology_output_words):
-                    details = '\n\n'.join(nca_stdout[2:5])
-                else:
-                    details = '\n\n'.join(nca_stdout[1:4])
-            else:
-                details = ''
-            rule_results.append(RuleResults(rule.name, nca_run.returncode == 0, details))
-            os.remove(rule_filename)
+            fixed_args += [query, str(rule_filename.absolute())]
+            nca_run, details = self._run_network_config_analyzer(fixed_args, args.debug)
+            rule_results.append(RuleResults(rule.name, nca_run == 0, details))
+            try:
+                os.remove(rule_filename)
+            except PermissionError:
+                print(f'{rule_filename} could not be deleted automatically', file=sys.stderr)
 
         output = '\n'.join(rule_result.to_str(args.format) for rule_result in rule_results)
         num_violated_rules = len([rule_result for rule_result in rule_results if not rule_result.satisfied])
@@ -165,8 +196,6 @@ def netpol_verify_main(args=None):
     parser.add_argument('--out_file', '-o', type=argparse.FileType('w'), help='A file to dump output into')
     parser.add_argument('--format', type=str, default='md', help='Output format ("md" or "txt")')
     parser.add_argument('--ghe_token', '--gh_token', type=str, help='A valid token to access a GitHub repository')
-    parser.add_argument('--nca_path', type=str, default='/nca',
-                        help='The path to where Network-Config-Analyzer is installed')
     parser.add_argument('--tmp_dir', type=str, default='/tmp',
                         help="A directory into which verifier's temporary files can be written")
     parser.add_argument('--debug', type=int, help="Set to 1 to print debug information")
@@ -176,7 +205,7 @@ def netpol_verify_main(args=None):
     if args.ghe_token:
         os.environ['GHE_TOKEN'] = args.ghe_token
 
-    npv = NetpolVerifier(args.netpol_file, args.baseline, args.repo, args.nca_path)
+    npv = NetpolVerifier(args.netpol_file, args.baseline, args.repo)
     ret_val = npv.verify(args)
     return 0 if args.return_0 else ret_val
 

--- a/src/baseline_verify.py
+++ b/src/baseline_verify.py
@@ -86,7 +86,6 @@ class NetpolVerifier:
         for rule in self.baseline_rules:
             rule_filename = Path(args.tmp_dir, f'{rule.name}.yaml')
             with open(rule_filename, 'w') as baseline_file:
-                # TODO: use to_netpol() for rules with namespace
                 policies_list = rule.to_global_netpol_calico()
                 yaml.dump_all(policies_list, baseline_file)
 
@@ -95,7 +94,12 @@ class NetpolVerifier:
             if args.debug is not None:
                 details = nca_run.stdout + '\n' + nca_run.stderr
             elif nca_run.returncode != 0:
-                details = '\n\n'.join(str(nca_run.stdout).split('\n')[2:5])
+                topology_output_words = ['cluster has', 'unique endpoints', 'namespaces']
+                nca_stdout = str(nca_run.stdout).split('\n')
+                if all(word in nca_stdout[1] for word in topology_output_words):
+                    details = '\n\n'.join(nca_stdout[2:5])
+                else:
+                    details = '\n\n'.join(nca_stdout[1:4])
             else:
                 details = ''
             rule_results.append(RuleResults(rule.name, nca_run.returncode == 0, details))


### PR DESCRIPTION
#22 ..
Hi @zivnevo ,
Some notes on this commit:

Runnig NCA's main function (instead of as a subprocess) caused some issues:
1. stdout and stderr print:
calling the main function , automatically prints its output, so in order to skip this , I did the following:
-> redirected the sys.stdout into a buffer before calling nca  (then after it finishes return it to sys.stdout)
-> unfortunately, redirecting sys.stderr into a buffer didn't work, so I used a hack to "hide" it when the debug mode is off with a `@contextmanager` method

2. removing the "tmp/<rule> (the NetworkPolicy) file caused an exception on my local workspace :

> PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: '..\\tmp\\allow-access-to-google.yaml'
 
in this commit , I wrapped the remove call with a try..except block. 
      ```
      try:
                os.remove(rule_filename)
            except PermissionError:
                print(f'{rule_filename} could not be deleted automatically', file=sys.stderr) ```
Another solution may be to check and wait until the "nca.exe" is finished and try to remove the file then.
Or may it help if we close the networkPolicy files on nca?
would like to know your idea on this